### PR TITLE
(main.js) fixed the window size so that it's no longer resizable

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ let win
 
 function createWindow () {
   // Create the browser window.
-  win = new BrowserWindow({ width: 720, height: 400  })
+  win = new BrowserWindow({ width: 720, height: 400, resizable: false  })
 
   // and load the index.html of the app.
   win.loadURL(url.format({


### PR DESCRIPTION
Fixes #50 .

Changes proposed in this pull request:
- added `resizable: false` flag to the BrowserWindow parameters. tested and is no longer resizable. 
