### PR TITLE
Fix broken link to docs/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 Check [Our Docs](./docs/index.md) for **building**  and **installing** instructions.
 
 
-If you would like to contribute to Deer, see [Our Docs](./docs/index.md) too.
+If you would like to contribute to Deer, see [Our Docs](./docs/README.md) too.
 
 ### Get in touch!
 


### PR DESCRIPTION
Fixes README.md.

Changes proposed in this pull request:
- Change link in README.md from docs/index.md to docs/README.md