### PR TITLE
Fixes #93: Split lines in packaging documentation (#93)

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -4,7 +4,7 @@ Now you can build and distribute Deer easily and generate binaries for various p
 
 
 ## For Linux
-Currently, Deer supports deb, rpm and zip packages
+Currently, Deer supports deb, rpm and zip packages.  
 To generate the packages use, the one you need according to your distributions.
 ``` bash
 npm run release:linux:deb
@@ -14,7 +14,7 @@ npm run release:linux:zip
 
 
 ## For Mac OS
-Currently, Deer supports dmg package
+Currently, Deer supports dmg package.  
 To generate the packages, use the one you need according to your distributions.
 ``` bash
 npm run release:mac
@@ -22,7 +22,7 @@ npm run release:mac
 
 
 ## For Windows
-Currently, Deer supports ia32 and x64 architectures.
+Currently, Deer supports ia32 and x64 architectures.  
 To generate the packages, use the one you need according to your architecture.
 ``` bash
 npm run release:win32


### PR DESCRIPTION
Fixes #93 : Split lines in packaging documentation (#93).

Changes proposed in this pull request:
- Split lines in packaging documentation