### PR TITLE
 Fixed #134 Now you can delete a note even if not saved

### DIFF
--- a/app/actions/note.js
+++ b/app/actions/note.js
@@ -97,13 +97,27 @@ export const deleteNote = () => (dispatch, getState) => {
 
   const state = getState().noteReducer
   const noteIndex = state.activeNoteIndex
-  removeNote(state.notes[noteIndex].id,
-    state.notes[noteIndex].rev).then((result) => {
-    dispatch(deleteNoteFromList(result.id))
-    dispatch(setActiveNoteIndex(ACTIONS.NOT_SELECTED_NOTE))
-    dispatch(setNoteStatus(NOTE_STATUS.NOTE_DELETE_SUCCESS))
-  }).catch((err) => {
+  try {
+    // This is done just to make sure it exist before deleting it.
+    getNote(state.notes[noteIndex].id).then(() => {
+      removeNote(state.notes[noteIndex].id,
+        state.notes[noteIndex].rev).then((result) => {
+        dispatch(deleteNoteFromList(result.id))
+        dispatch(setActiveNoteIndex(ACTIONS.NOT_SELECTED_NOTE))
+        dispatch(setNoteStatus(NOTE_STATUS.NOTE_DELETE_SUCCESS))
+      }).catch((err) => {
+        dispatch(setNoteStatus(NOTE_STATUS.NOTE_DELETE_FAIL))
+        logger.error('Unable to remove note ' + err)
+      })
+    }).catch((err) => {
+      if (err) {
+        dispatch(deleteNoteFromList(state.notes[noteIndex].id))
+        dispatch(setActiveNoteIndex(ACTIONS.NOT_SELECTED_NOTE))
+        dispatch(setNoteStatus(NOTE_STATUS.NOTE_DELETE_SUCCESS))
+      }
+    })
+  } catch (err) {
     dispatch(setNoteStatus(NOTE_STATUS.NOTE_DELETE_FAIL))
     logger.error('Unable to remove note ' + err)
-  })
+  }
 }

--- a/app/components/StatusModal.js
+++ b/app/components/StatusModal.js
@@ -23,6 +23,7 @@ export default class StatusModal extends Component {
         break
       case NOTE_STATUS.NOTE_LOAD_SUCCESS:
       case NOTE_STATUS.NOTE_DELETE_SUCCESS:
+        this.props.setNewNoteDisabled(false)
         this.props.updateNoteStatus()
         break
       default:


### PR DESCRIPTION
Fixes #134 

Changes proposed in this pull request:
- Now you can delete a note even if the note is not saved in the DB
Basically, I check if the note is in the db before I call `removeNote` which will trigger an error since the `doc` doesn't exits yet. and instead I remove it from the list and I set the `New Note` to active again, so you can create a new note again.

### Test:
- Open the app
- Click on New Note
- Click on Delete Note
- Click on New Note

All these things should properly work.
