### PR TITLE
Fixes #135 Now you don't get an error when changing from saved and not saved notes

### DIFF
--- a/app/actions/note.js
+++ b/app/actions/note.js
@@ -79,16 +79,25 @@ export const saveNote = () => (dispatch, getState) => {
 // Async method, used for getting active note content from database and loads it.
 export const fetchNote = () => (dispatch, getState) => {
   setNoteStatus(NOTE_STATUS.LOADING_NOTE)
-
   const state = getState().noteReducer
   const noteIndex = state.activeNoteIndex
-  getNote(state.notes[noteIndex].id).then((result) => {
-    dispatch(loadNoteContent(convertFromRaw(result.content)))
-    dispatch(setNoteStatus(NOTE_STATUS.NOTE_LOAD_SUCCESS))
-  }).catch((err) => {
-    dispatch(setNoteStatus(NOTE_STATUS.NOTE_LOAD_FAIL))
-    logger.error('Unable to get note ' + err)
-  })
+  try {
+    // This is to just get the note from the db and load it's content if already saved.
+    getNote(state.notes[noteIndex].id).then((result) => {
+      dispatch(loadNoteContent(convertFromRaw(result.content)))
+      dispatch(setNoteStatus(NOTE_STATUS.NOTE_LOAD_SUCCESS))
+    // Handle those new notes that are not saved yet.
+    }).catch((err) => {
+      if (err) {
+        dispatch(setNoteStatus(NOTE_STATUS.NOTE_LOAD_SUCCESS))
+      }
+    })
+  } catch (err) {
+    if (err) {
+      dispatch(setNoteStatus(NOTE_STATUS.NOTE_LOAD_FAIL))
+      logger.error('Unable to get note ' + err)
+    }
+  }
 }
 
 // Async method, used for removing active note from database.


### PR DESCRIPTION
Fixes #135 

Changes proposed in this pull request:
- This will fix the issue that occurs when you select a note that is not saved since it will try to get it from the db.
- If the note is not in the db it will not try to get the content of it, just display the message saying that it loaded

### Test:
- First open the app
- Create a note and save it
- Create a new note, **do not save it**
- Click the saved note
- Click the unsaved note

No errors should be triggered.
