### PR TITLE
Fixes #154 Keep showing welcome page till next is clicked

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Switch, Route, BrowserRouter, Redirect } from 'react-router-dom'
+import { Switch, Route, Redirect, HashRouter } from 'react-router-dom'
 import routes from '../routes'
 
 export default () => (
-  <BrowserRouter>
+  <HashRouter>
     <Switch>
       {routes.map((route, index) => (
         <Route
@@ -15,5 +15,5 @@ export default () => (
       ))}
       <Redirect to='/' />
     </Switch>
-  </BrowserRouter>
+  </HashRouter>
 )

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -5,14 +5,10 @@ import NoteList from './../containers/NoteList'
 import HomeContent from './../containers/HomeContent'
 import YesNoModal from './../containers/YesNoModal'
 import StatusModal from './../containers/StatusModal'
-import {
-  checkRedirectToWelcomePage,
-  setNotFirstTimeFlag
-} from '../../utils/api.electron'
+import { checkRedirectToWelcomePage } from '../../utils/api.electron'
 
 export default () => {
   if (checkRedirectToWelcomePage()) {
-    setNotFirstTimeFlag()
     return (
       <Redirect to='/welcome' />
     )

--- a/app/components/Welcome.js
+++ b/app/components/Welcome.js
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Spinner from './Spinner'
 
+import { setNotFirstTimeFlag } from '../../utils/api.electron'
+
 export default class Welcome extends Component {
   componentWillMount () {
     this.props.updateLang()
@@ -11,6 +13,10 @@ export default class Welcome extends Component {
 
   componentWillUnmount () {
     this.props.stopUpdateLang()
+  }
+
+  goToNext () {
+    setNotFirstTimeFlag()
   }
 
   render () {
@@ -34,6 +40,7 @@ export default class Welcome extends Component {
         <br />
         <Link to='/'>
           <Button
+            onClick={this.goToNext}
             className='center-button'
             color='primary'>
             {lang.nextBtn}


### PR DESCRIPTION
Fixes #154 Keep showing welcome page till next is clicked

Changes proposed in this pull request:
- Change BrowserRouter to HashRouter
Electron has problems to deal with states, like reloading a page always result in a blank page.
- Move `setNotFirstTimeFlag` from Home#render method to Welcome#goToNext click method
